### PR TITLE
conf/local.conf.sample: account for the "ACCEPT EULA" variable name change

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -257,4 +257,4 @@ PRSERV_HOST = "localhost:0"
 
 
 # For Qualcomm firwmare we need to accept the end user licence terms ("EULA")
-ACCEPT_QCOM_EULA = "1"
+ACCEPT_EULA_dragonboard-410c = "1"


### PR DESCRIPTION
See the changes to recipes-bsp/firmware/firmware-qcom-dragonboard410c_1.2.0.bb
in meta-qcom layer.
https://github.com/ndechesne/meta-qcom/commit/b9182e913e18f538c633c6a251149471f1418bbd

Signed-off-by: Andrey Konovalov andrey.konovalov@linaro.org
