### PR TITLE
Add ocdmi recipe to master-staging

### DIFF
--- a/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
+++ b/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
@@ -16,7 +16,7 @@ S = "${WORKDIR}/git"
 #
 # * debug-build : Builds OCDM with debug symbols and verbose logging.
 
-DEPENDS_append = "  openssl "
+DEPENDS_append = "  openssl portmap"
 
 # Only ClearKey implementation depends on ssl
 DEPENDS_remove = " \

--- a/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
+++ b/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
@@ -12,19 +12,17 @@ SRCREV_pn-ocdmi ?= "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
-EXTRA_OECONF_append = "${@base_contains('MACHINE_FEATURES', 'optee', '--enable-aes-ta', '', d)} "
+EXTRA_OECONF_append = "${@bb.utils.contains('MACHINE_FEATURES', 'optee', '--enable-aes-ta', '', d)} "
 
 # * use-playready : Enables support for Playready CDMI.
 #
 # * debug-build : Builds OCDM with debug symbols and verbose logging.
 
-DEPENDS_append = " openssl portmap"
-
-DEPENDS_append = "${@base_contains('MACHINE_FEATURES','optee',' optee-aes-decryptor ','',d)}"
-
-# Only ClearKey implementation depends on ssl
-DEPENDS_remove = " \
-  ${@base_contains('PACKAGECONFIG','use-playready','openssl','',d)} \
-  "
+# Only ClearKey implementation depends on ssl:
+DEPENDS_append = " \
+    ${@bb.utils.contains('PACKAGECONFIG','use-playready','','openssl',d)} \
+    portmap \
+    ${@bb.utils.contains('MACHINE_FEATURES','optee','optee-aes-decryptor','',d)} \
+"
 
 inherit autotools

--- a/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
+++ b/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
@@ -7,7 +7,7 @@ DESCRIPTION = "Open Content Decryption Module"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ea83f8bc099c40bde8c4f2441a6eb40b"
 
-SRC_URI = "git://github.com/kuscsik/linaro-cdmi.git;protocol=https;branch=master"
+SRC_URI = "git://github.com/linaro-home/open-content-decryption-module-cdmi.git;protocol=https;branch=master"
 SRCREV_pn-ocdmi ?= "${AUTOREV}"
 
 S = "${WORKDIR}/git"

--- a/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
+++ b/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
@@ -20,7 +20,7 @@ EXTRA_OECONF_append = "${@base_contains('MACHINE_FEATURES', 'optee', '--enable-a
 
 DEPENDS_append = " openssl portmap"
 
-DEPENDS_append = "${@base_contains('PACKAGECONFIG','optee','optee-aes-decryptor','',d)}"
+DEPENDS_append = "${@base_contains('MACHINE_FEATURES','optee',' optee-aes-decryptor ','',d)}"
 
 # Only ClearKey implementation depends on ssl
 DEPENDS_remove = " \

--- a/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
+++ b/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
@@ -1,0 +1,26 @@
+#
+# This file was derived from the 'Hello World!' example recipe in the
+# Yocto Project Development Manual.
+#
+
+DESCRIPTION = "Open Content Decryption Module"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ea83f8bc099c40bde8c4f2441a6eb40b"
+
+SRC_URI = "git://github.com/kuscsik/linaro-cdmi.git;protocol=https;branch=master"
+SRCREV_pn-ocdmi ?= "${AUTOREV}"
+
+S = "${WORKDIR}/git"
+
+# * use-playready : Enables support for Playready CDMI.
+#
+# * debug-build : Builds OCDM with debug symbols and verbose logging.
+
+DEPENDS_append = "  openssl "
+
+# Only ClearKey implementation depends on ssl
+DEPENDS_remove = " \
+  ${@base_contains('PACKAGECONFIG','use-playready','openssl','',d)} \
+  "
+
+inherit autotools

--- a/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
+++ b/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
@@ -12,11 +12,15 @@ SRCREV_pn-ocdmi ?= "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
+EXTRA_OECONF_append = "${@base_contains('MACHINE_FEATURES', 'optee', '--enable-aes-ta', '', d)} "
+
 # * use-playready : Enables support for Playready CDMI.
 #
 # * debug-build : Builds OCDM with debug symbols and verbose logging.
 
-DEPENDS_append = "  openssl portmap"
+DEPENDS_append = " openssl portmap"
+
+DEPENDS_append = "${@base_contains('PACKAGECONFIG','optee','optee-aes-decryptor','',d)}"
 
 # Only ClearKey implementation depends on ssl
 DEPENDS_remove = " \


### PR DESCRIPTION
This is a part of the effort to forward port OpenCDM from LHG's chromium_45 to cromium currently in meta-browser (53.0.2785.143 for chromium-wayland atm).

This patch set is not enough to get anything working, but it lets the chromium build for HiKey to complete OK w/o disabling/removing any optee dependent stuff from meta-lhg (the " ${@base_contains('MACHINE_FEATURES', 'optee', 'optee-aes-decryptor ocdmi portmap', '', d)}" line inrpb-westonchromium-image.bb in particular).