### PR TITLE
Update to chromium v53

### DIFF
--- a/meta-lhg/recipes-browser/chromium/chromium-wayland_%.bbappend
+++ b/meta-lhg/recipes-browser/chromium/chromium-wayland_%.bbappend
@@ -1,4 +1,4 @@
-PACKAGECONFIG_append = " ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'use-ocdm', '', d)}"
+PACKAGECONFIG_append = " ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'use-ocdm', '', d)}  proprietary-codecs"
 
 OCDM_GIT_BRANCH="chromium-53.0.2785.143"
 OCDM_DESTSUFIX="ocdm"

--- a/meta-lhg/recipes-browser/chromium/chromium-wayland_%.bbappend
+++ b/meta-lhg/recipes-browser/chromium/chromium-wayland_%.bbappend
@@ -10,9 +10,9 @@ SRCREV_ocdm = "${AUTOREV}"
 DEPENDS_append = " ${@bb.utils.contains('PACKAGECONFIG', 'use-ocdm', 'ocdmi', '', d)} "
 
 python add_ocdm_patches() {
-    import glob
     srcdir = d.getVar('WORKDIR', True)
-    d.appendVar('SRC_URI', "file://" + srcdir + "/ocdm/patch/add_ocdm_keyssystems.patch")
+    d.appendVar('SRC_URI', " file://" + srcdir + "/ocdm/patch/add_ocdm_keyssystems.patch")
+    d.appendVar('SRC_URI', " file://" + srcdir + "/ocdm/patch/add_playready_keysystem.patch")
 }
 
 copy_ocdm_files() {

--- a/meta-lhg/recipes-browser/chromium/chromium-wayland_%.bbappend
+++ b/meta-lhg/recipes-browser/chromium/chromium-wayland_%.bbappend
@@ -3,6 +3,11 @@ PACKAGECONFIG_append = " ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'use-
 OCDM_GIT_BRANCH="chromium-53.0.2785.143"
 OCDM_DESTSUFIX="ocdm"
 
+#This is deliberately separated from CHROMIUM_BUILD_TYPE so we can
+#easily enable debug builds of just the OpenCDM plugin for symbolic
+#debugging using --ppapi-plugin-launcher='gdbserver localhost:4444'
+OCDM_CHROMIUM_BUILD_TYPE="Release"
+
 SRC_URI += "${@bb.utils.contains('PACKAGECONFIG', 'use-ocdm', '\
     git://github.com/linaro-home/open-content-decryption-module.git;protocol=https;branch=${OCDM_GIT_BRANCH};name=ocdm;destsuffix=${OCDM_DESTSUFIX}\
     ', '', d)}"
@@ -24,15 +29,15 @@ do_unpack[postfuncs] += "${@bb.utils.contains('PACKAGECONFIG', 'use-ocdm', 'copy
 
 do_compile_append() {
     if [ -n "${@bb.utils.contains('PACKAGECONFIG', 'use-ocdm', 'use-ocdm', '', d)}" ]; then
-        ninja -C ${S}/out/${CHROMIUM_BUILD_TYPE} opencdmadapter
+        ninja -C ${S}/out/${OCDM_CHROMIUM_BUILD_TYPE} opencdmadapter
     fi
 }
 
 do_install_append() {
     if [ -n "${@bb.utils.contains('PACKAGECONFIG', 'use-ocdm', 'use-ocdm', '', d)}" ]; then
-        install -Dm 0755 ${B}/out/${CHROMIUM_BUILD_TYPE}/libopencdmadapter.so \
+        install -Dm 0755 ${B}/out/${OCDM_CHROMIUM_BUILD_TYPE}/libopencdmadapter.so \
             ${D}${libdir}/${BPN}/libopencdmadapter.so
-        install -Dm 0755 ${B}/out/${CHROMIUM_BUILD_TYPE}/libopencdm.so \
+        install -Dm 0755 ${B}/out/${OCDM_CHROMIUM_BUILD_TYPE}/libopencdm.so \
             ${D}${libdir}/${BPN}/libopencdm.so
     fi
 }

--- a/meta-lhg/recipes-browser/chromium/chromium-wayland_%.bbappend
+++ b/meta-lhg/recipes-browser/chromium/chromium-wayland_%.bbappend
@@ -1,0 +1,38 @@
+PACKAGECONFIG_append = " ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'use-ocdm', '', d)}"
+
+OCDM_GIT_BRANCH="chromium-53.0.2785.143"
+OCDM_DESTSUFIX="ocdm"
+
+SRC_URI += "${@bb.utils.contains('PACKAGECONFIG', 'use-ocdm', '\
+    git://github.com/linaro-home/open-content-decryption-module.git;protocol=https;branch=${OCDM_GIT_BRANCH};name=ocdm;destsuffix=${OCDM_DESTSUFIX}\
+    ', '', d)}"
+SRCREV_ocdm = "${AUTOREV}"
+DEPENDS_append = " ${@bb.utils.contains('PACKAGECONFIG', 'use-ocdm', 'ocdmi', '', d)} "
+
+python add_ocdm_patches() {
+    import glob
+    srcdir = d.getVar('WORKDIR', True)
+    d.appendVar('SRC_URI', "file://" + srcdir + "/ocdm/patch/add_ocdm_keyssystems.patch")
+}
+
+copy_ocdm_files() {
+    cp -r ${WORKDIR}/ocdm ${S}/media/cdm/ppapi/external_open_cdm
+}
+
+do_patch[prefuncs] += "${@bb.utils.contains('PACKAGECONFIG', 'use-ocdm', 'add_ocdm_patches', '', d)}"
+do_unpack[postfuncs] += "${@bb.utils.contains('PACKAGECONFIG', 'use-ocdm', 'copy_ocdm_files', '', d)}"
+
+do_compile_append() {
+    if [ -n "${@bb.utils.contains('PACKAGECONFIG', 'use-ocdm', 'use-ocdm', '', d)}" ]; then
+        ninja -C ${S}/out/${CHROMIUM_BUILD_TYPE} opencdmadapter
+    fi
+}
+
+do_install_append() {
+    if [ -n "${@bb.utils.contains('PACKAGECONFIG', 'use-ocdm', 'use-ocdm', '', d)}" ]; then
+        install -Dm 0755 ${B}/out/${CHROMIUM_BUILD_TYPE}/libopencdmadapter.so \
+            ${D}${libdir}/${BPN}/libopencdmadapter.so
+        install -Dm 0755 ${B}/out/${CHROMIUM_BUILD_TYPE}/libopencdm.so \
+            ${D}${libdir}/${BPN}/libopencdm.so
+    fi
+}

--- a/meta-lhg/recipes-browser/chromium/chromium_%.bbappend
+++ b/meta-lhg/recipes-browser/chromium/chromium_%.bbappend
@@ -1,4 +1,4 @@
 # chromium_45 fails to work with newer version of nns which is used in krogoth
 PREFERRED_VERSION_nss = "3.19.%"
 
-PACKAGECONFIG_append = " ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'use-ocdm', '', d)}"
+PACKAGECONFIG_append = " ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'use-ocdm', '', d)} proprietary-codecs"

--- a/meta-lhg/recipes-samples/images/rpb-westonchromium-image.bb
+++ b/meta-lhg/recipes-samples/images/rpb-westonchromium-image.bb
@@ -2,6 +2,6 @@ require recipes-samples/images/rpb-weston-image.bb
 
 CORE_IMAGE_BASE_INSTALL += " \
     libexif \
-    chromium \
+    chromium-wayland \
     ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'optee-aes-decryptor ocdmi portmap', '', d)} \
     "

--- a/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
+++ b/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
@@ -16,7 +16,7 @@ S = "${WORKDIR}/git"
 #
 # * debug-build : Builds OCDM with debug symbols and verbose logging.
 
-DEPENDS_append = "  openssl "
+DEPENDS_append = "  openssl portmap"
 
 # Only ClearKey implementation depends on ssl
 DEPENDS_remove = " \

--- a/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
+++ b/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
@@ -12,19 +12,17 @@ SRCREV_pn-ocdmi ?= "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
-EXTRA_OECONF_append = "${@base_contains('MACHINE_FEATURES', 'optee', '--enable-aes-ta', '', d)} "
+EXTRA_OECONF_append = "${@bb.utils.contains('MACHINE_FEATURES', 'optee', '--enable-aes-ta', '', d)} "
 
 # * use-playready : Enables support for Playready CDMI.
 #
 # * debug-build : Builds OCDM with debug symbols and verbose logging.
 
-DEPENDS_append = " openssl portmap"
-
-DEPENDS_append = "${@base_contains('MACHINE_FEATURES','optee',' optee-aes-decryptor ','',d)}"
-
-# Only ClearKey implementation depends on ssl
-DEPENDS_remove = " \
-  ${@base_contains('PACKAGECONFIG','use-playready','openssl','',d)} \
-  "
+# Only ClearKey implementation depends on ssl:
+DEPENDS_append = " \
+    ${@bb.utils.contains('PACKAGECONFIG','use-playready','','openssl',d)} \
+    portmap \
+    ${@bb.utils.contains('MACHINE_FEATURES','optee','optee-aes-decryptor','',d)} \
+"
 
 inherit autotools

--- a/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
+++ b/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
@@ -14,13 +14,13 @@ S = "${WORKDIR}/git"
 
 EXTRA_OECONF_append = "${@bb.utils.contains('MACHINE_FEATURES', 'optee', '--enable-aes-ta', '', d)} "
 
-# * use-playready : Enables support for Playready CDMI.
+# * --enable-playready : Enables support for Playready CDMI.
 #
-# * debug-build : Builds OCDM with debug symbols and verbose logging.
+# * --enable-debug : Builds OCDM with debug symbols and verbose logging.
 
 # Only ClearKey implementation depends on ssl:
 DEPENDS_append = " \
-    ${@bb.utils.contains('PACKAGECONFIG','use-playready','','openssl',d)} \
+    ${@bb.utils.contains('PACKAGECONFIG','--enable-playready','','openssl',d)} \
     portmap \
     ${@bb.utils.contains('MACHINE_FEATURES','optee','optee-aes-decryptor','',d)} \
 "

--- a/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
+++ b/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
@@ -7,7 +7,7 @@ DESCRIPTION = "Open Content Decryption Module"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ea83f8bc099c40bde8c4f2441a6eb40b"
 
-SRC_URI = "git://github.com/kuscsik/linaro-cdmi.git;protocol=https;branch=master"
+SRC_URI = "git://github.com/linaro-home/open-content-decryption-module-cdmi.git;protocol=https;branch=master"
 SRCREV_pn-ocdmi ?= "${AUTOREV}"
 
 S = "${WORKDIR}/git"

--- a/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
+++ b/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
@@ -20,7 +20,7 @@ EXTRA_OECONF_append = "${@base_contains('MACHINE_FEATURES', 'optee', '--enable-a
 
 DEPENDS_append = " openssl portmap"
 
-DEPENDS_append = "${@base_contains('PACKAGECONFIG','optee','optee-aes-decryptor','',d)}"
+DEPENDS_append = "${@base_contains('MACHINE_FEATURES','optee',' optee-aes-decryptor ','',d)}"
 
 # Only ClearKey implementation depends on ssl
 DEPENDS_remove = " \

--- a/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
+++ b/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
@@ -1,0 +1,26 @@
+#
+# This file was derived from the 'Hello World!' example recipe in the
+# Yocto Project Development Manual.
+#
+
+DESCRIPTION = "Open Content Decryption Module"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ea83f8bc099c40bde8c4f2441a6eb40b"
+
+SRC_URI = "git://github.com/kuscsik/linaro-cdmi.git;protocol=https;branch=master"
+SRCREV_pn-ocdmi ?= "${AUTOREV}"
+
+S = "${WORKDIR}/git"
+
+# * use-playready : Enables support for Playready CDMI.
+#
+# * debug-build : Builds OCDM with debug symbols and verbose logging.
+
+DEPENDS_append = "  openssl "
+
+# Only ClearKey implementation depends on ssl
+DEPENDS_remove = " \
+  ${@base_contains('PACKAGECONFIG','use-playready','openssl','',d)} \
+  "
+
+inherit autotools

--- a/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
+++ b/meta-lhg/recipes-security/ocdm/ocdmi_git.bb
@@ -12,11 +12,15 @@ SRCREV_pn-ocdmi ?= "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
+EXTRA_OECONF_append = "${@base_contains('MACHINE_FEATURES', 'optee', '--enable-aes-ta', '', d)} "
+
 # * use-playready : Enables support for Playready CDMI.
 #
 # * debug-build : Builds OCDM with debug symbols and verbose logging.
 
-DEPENDS_append = "  openssl portmap"
+DEPENDS_append = " openssl portmap"
+
+DEPENDS_append = "${@base_contains('PACKAGECONFIG','optee','optee-aes-decryptor','',d)}"
 
 # Only ClearKey implementation depends on ssl
 DEPENDS_remove = " \


### PR DESCRIPTION
This updates meta-lhg to work with mainline chromium-wayland_53.0.2785.143.bb recipe.

The chromium_%.bbappend inended to be used with LHG's chromium_v45 fork si no longer needed, the meta-lhg/recipes-support/nss/nss* included. But let's keep them here for now - just in case.