### PR TITLE
mesa_%.bbappend: resolve conflict with ti-sgx-ddk-um and libgbm from …

### DIFF
--- a/meta-lhg-integration/recipes-graphics/mesa/mesa_%.bbappend
+++ b/meta-lhg-integration/recipes-graphics/mesa/mesa_%.bbappend
@@ -1,0 +1,10 @@
+do_install_append_omap-15() {
+    # Remove libgbm provided by Mesa as omap-a15 uses the one from meta-ti
+    rm -f ${D}/${libdir}/libgbm.*
+}
+
+PROVIDES_remove = "${@bb.utils.contains("MACHINE_FEATURES", "sgx", "virtual/libgles1 virtual/libgles2 virtual/egl", "", d)}"
+
+PACKAGECONFIG_remove = "${@bb.utils.contains("MACHINE_FEATURES", "sgx", "gbm egl gles", "", d)}"
+
+PACKAGES_remove = "${@bb.utils.contains("MACHINE_FEATURES", "sgx", "libgbm libgbm-dev", "", d)}"


### PR DESCRIPTION
…meta-ti

In particular, this enables building ffplay for omap-a15 based boards.

Signed-off-by: Andrey Konovalov <andrey.konovalov@linaro.org>