### PR TITLE
rpb-westonchromium-image: add ffmpeg (and ffplay)

### DIFF
--- a/meta-lhg/recipes-samples/images/rpb-westonchromium-image.bb
+++ b/meta-lhg/recipes-samples/images/rpb-westonchromium-image.bb
@@ -11,6 +11,7 @@ GSTREAMER_ACCEL_MM_omap-a15 = "${@bb.utils.contains('MACHINE_FEATURES', 'mmip', 
 GSTREAMER_ACCEL_MM_append_dra7xx = "${@bb.utils.contains('MACHINE_FEATURES', 'mmip', " gstreamer1.0-plugins-vpe", '', d)}"
 
 CORE_IMAGE_BASE_INSTALL += " \
+    ffmpeg \
     libexif \
     ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'optee-aes-decryptor ocdmi portmap', '', d)} \
     ${ACCEL_FW} \


### PR DESCRIPTION
Add ffmpeg (ffplay included) to the LHG's weston image - just like it was
done for the packagegroup-rpb-x11.

Signed-off-by: Andrey Konovalov <andrey.konovalov@linaro.org>