### PR TITLE
Adding LinaroCDM+CDMi+OPTEE to lhg-westeros-wpe-image

### DIFF
--- a/meta-lhg-wpe/recipes-drm/opencdm/opencdm_git.bb
+++ b/meta-lhg-wpe/recipes-drm/opencdm/opencdm_git.bb
@@ -1,0 +1,37 @@
+SUMMARY = "Open Content Decryption Module for WPE"
+HOMEPAGE = "https://www.fokus.fraunhofer.de/en"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ea83f8bc099c40bde8c4f2441a6eb40b"
+
+DEPENDS = "glib-2.0"
+DEPENDS_append_libc-musl = " libtirpc"
+CPPFLAGS_append_libc-musl = " -I${STAGING_INCDIR}/tirpc"
+CXXFLAGS_append_libc-musl = " -I${STAGING_INCDIR}/tirpc"
+CFLAGS_append_libc-musl = " -I${STAGING_INCDIR}/tirpc"
+LDFLAGS_append_libc-musl = " -ltirpc"
+
+SRCREV = "${AUTOREV}"
+
+PV = "1.0.gitr${SRCPV}"
+S = "${WORKDIR}/git"
+
+SRC_URI = "git://github.com/linaro-home/open-content-decryption-module;branch=chromium-53.0.2785.143"
+
+CXXFLAGS += "-Wno-narrowing"
+
+do_compile_prepend() {
+        mkdir -p ${S}/src/browser/wpe/test/bin
+}
+
+do_install(){
+        install -d ${D}${includedir}
+        install -d ${D}${libdir}
+        install -m 0755 ${B}/src/browser/wpe/lib/libocdm.so ${D}${libdir}
+        install -m 0755 ${B}/src/browser/wpe/include/*.h ${D}${includedir}
+}
+
+FILES_SOLIBSDEV = ""
+FILES_${PN} += "${libdir}/*.so"
+FILES_${PN} += "${includedir}/*.h"
+
+PARALLEL_MAKE = ""

--- a/meta-lhg-wpe/recipes-samples/images/lhg-westeros-wpe-image.bb
+++ b/meta-lhg-wpe/recipes-samples/images/lhg-westeros-wpe-image.bb
@@ -13,6 +13,12 @@ CORE_IMAGE_BASE_INSTALL += " \
     westeros-simplebuffer \
     westeros-simpleshell \
     westeros-soc \
+    optee-os \
+    optee-client \
+    optee-aes-decryptor \
+    portmap \
+    ocdmi \
+    opencdm \
     wpewebkit \
     wpebackend-rdk \
     wpelauncher \

--- a/meta-lhg-wpe/recipes-wpe/wpewebkit/wpewebkit_0.1.bbappend
+++ b/meta-lhg-wpe/recipes-wpe/wpewebkit/wpewebkit_0.1.bbappend
@@ -1,8 +1,9 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-# override WPEWebKit branch to wpe-20161117 aligining with Metrological
-BASE_URI = "git://github.com/WebPlatformForEmbedded/WPEWebKit.git;protocol=git;branch=wpe-20161117"
+# override WPEWebKit till ClearKey PR is merged
+BASE_URI = "git://github.com/psivasubramanian/WebKitForWayland;protocol=git;branch=patch-8"
 SRC_URI_append = "file://0001-incompatitable-types-fix.patch"
+SRCREV = "233a70860b59c47a7c6bdda237412f987be0c4f2"
 
 # removing commercial plugins 
 RDEPS_EXTRA_remove = " \
@@ -12,3 +13,6 @@ RDEPS_EXTRA_remove = " \
                      
 # remove playready
 PACKAGECONFIG_remove = "playready"
+
+# enable opencdm
+PACKAGECONFIG_append = " opencdm"


### PR DESCRIPTION
1. Add OpenCDM recipe for building CDM library for WPE
2. Enable opencdm in WPEWebKit
3. Add LinaroCDM, CDMi & OPTEE to lhg-westeros-wpe-image