### PR TITLE
igt-gpu-tools: add the git version of the recipe

### DIFF
--- a/meta-lhg-integration/recipes-graphics/igt-gpu-tools/igt-gpu-tools/0001-Add-another-path-of-testlist.patch
+++ b/meta-lhg-integration/recipes-graphics/igt-gpu-tools/igt-gpu-tools/0001-Add-another-path-of-testlist.patch
@@ -1,0 +1,30 @@
+From 539205653011a152916cbcc7e9e82738725cbd17 Mon Sep 17 00:00:00 2001
+From: Arthur She <arthur.she@linaro.org>
+Date: Mon, 25 Mar 2019 10:03:31 +0800
+Subject: [PATCH 1/1] Add another path of testlist.
+
+This patch adds another path of test list which is the place the
+igt-gpu-tools been installed in the target.
+
+Signed-off-by: Arthur She <arthur.she@linaro.org>
+---
+ scripts/run-tests.sh | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/scripts/run-tests.sh b/scripts/run-tests.sh
+index 4209dd8c..3438555e 100755
+--- a/scripts/run-tests.sh
++++ b/scripts/run-tests.sh
+@@ -30,7 +30,8 @@ PIGLIT=`which piglit 2> /dev/null`
+ 
+ if [ -z "$IGT_TEST_ROOT" ]; then
+ 	paths=("$ROOT/build/tests/test-list.txt"
+-	       "$ROOT/tests/test-list.txt")
++	       "$ROOT/tests/test-list.txt"
++	       "/usr/libexec/igt-gpu-tools/test-list.txt")
+ 	for p in "${paths[@]}"; do
+ 		if [ -f "$p" ]; then
+ 			echo "Found test list: \"$p\""
+-- 
+2.17.1
+

--- a/meta-lhg-integration/recipes-graphics/igt-gpu-tools/igt-gpu-tools_git.bb
+++ b/meta-lhg-integration/recipes-graphics/igt-gpu-tools/igt-gpu-tools_git.bb
@@ -1,0 +1,47 @@
+SUMMARY = "IGT GPU Tools"
+DESCRIPTION = "IGT GPU Tools is a collection of tools for development and testing of the DRM drivers"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=e4b3dd344780e0400593b21b115a6947"
+
+LICENSE_append = " & ISC"
+
+inherit autotools gtk-doc
+
+SRCREV = "${AUTOREV}"
+
+SRC_URI = "git://gitlab.freedesktop.org/drm/igt-gpu-tools.git;protocol=https  \
+           file://0001-igt-run-script.patch \
+"
+
+S = "${WORKDIR}/git"
+
+DEPENDS += "libdrm libpciaccess cairo udev glib-2.0 procps libunwind kmod openssl libxmlrpc gsl elfutils python3-mako"
+RDEPENDS_${PN} += "bash"
+
+PACKAGE_BEFORE_PN = "${PN}-benchmarks"
+
+EXTRA_OECONF = "--enable-chamelium --disable-intel --disable-amdgpu --enable-tests"
+COMPATIBLE_HOST = "(x86_64.*|i.86.*|arm.*|aarch64).*-linux"
+COMPATIBLE_HOST_libc-musl_class-target = "null"
+
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[audio] = "--enable-audio,--disable-audio,alsa-lib gsl"
+
+gputools_sysroot_preprocess() {
+	rm -f ${SYSROOT_DESTDIR}${libdir}/pkgconfig/intel-gen4asm.pc
+}
+SYSROOT_PREPROCESS_FUNCS += "gputools_sysroot_preprocess"
+
+do_install_append() {
+    install -d ${D}/usr/share/${BPN}/scripts
+    install ${S}/scripts/run-tests.sh ${D}/usr/share/${BPN}/scripts
+}
+
+FILES_${PN}-benchmarks += "${libexecdir}/${BPN}/benchmarks"
+FILES_${PN} += "\
+        ${libexecdir}/${BPN}/*\
+        ${libdir}/intel_aubdump.so \
+        ${datadir}/${BPN}/1080p-right.png\
+        ${datadir}/${BPN}/1080p-left.png\
+        ${datadir}/${BPN}/pass.png\
+        ${datadir}/${BPN}/test-list.txt"


### PR DESCRIPTION
Based on meta-intel/recipes-graphics/igt-gpu-tools/igt-gpu-tools_1.23.bb
Remove the dependency of X11 in order to build with Weston.
Add a patch to add a test list path to scripts/run-tests.sh