### PR TITLE
igt-gpu-tools: add git python3-six to runtime dependencies

### DIFF
--- a/meta-lhg-integration/recipes-graphics/igt-gpu-tools/igt-gpu-tools_git.bb
+++ b/meta-lhg-integration/recipes-graphics/igt-gpu-tools/igt-gpu-tools_git.bb
@@ -16,7 +16,7 @@ SRC_URI = "git://gitlab.freedesktop.org/drm/igt-gpu-tools.git;protocol=https  \
 S = "${WORKDIR}/git"
 
 DEPENDS += "libdrm libpciaccess cairo udev glib-2.0 procps libunwind kmod openssl xmlrpc-c gsl elfutils alsa-lib"
-RDEPENDS_${PN} += "bash python3-mako"
+RDEPENDS_${PN} += "bash python3-mako python3-six git"
 
 PACKAGE_BEFORE_PN = "${PN}-benchmarks"
 


### PR DESCRIPTION
These two packages, git and python3-six, are needed for igt, however, they are not included in am57xx-evm rpb-westonchromium-image.