### PR TITLE
igt-gpu-tools: add net-snmp to runtime dependencies

### DIFF
--- a/meta-lhg-integration/recipes-graphics/igt-gpu-tools/igt-gpu-tools_git.bb
+++ b/meta-lhg-integration/recipes-graphics/igt-gpu-tools/igt-gpu-tools_git.bb
@@ -14,7 +14,7 @@ SRC_URI = "git://gitlab.freedesktop.org/drm/igt-gpu-tools.git;protocol=https"
 S = "${WORKDIR}/git"
 
 DEPENDS += "libdrm libpciaccess cairo udev glib-2.0 procps libunwind kmod openssl xmlrpc-c gsl elfutils alsa-lib"
-RDEPENDS_${PN} += "bash python3-mako python3-six git"
+RDEPENDS_${PN} += "bash python python3-mako python3-six git net-snmp"
 
 PACKAGE_BEFORE_PN = "${PN}-benchmarks"
 


### PR DESCRIPTION
Add net-snmp which will be used to control Chamelium power to runtime
dependencies.

Signed-off-by: Arthur She <arthur.she@linaro.org>