### PR TITLE
meta-lhg*/layer.conf: add dunfell, drop thud from LAYERSERIES_COMPAT

### DIFF
--- a/meta-lhg-integration/conf/layer.conf
+++ b/meta-lhg-integration/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "lhg-integration"
 BBFILE_PATTERN_lhg-integration = "^${LAYERDIR}/"
 BBFILE_PRIORITY_lhg-integration = "7"
 
-LAYERSERIES_COMPAT_lhg-integration = "thud warrior zeus"
+LAYERSERIES_COMPAT_lhg-integration = "warrior zeus dunfell"

--- a/meta-lhg-wpe/conf/layer.conf
+++ b/meta-lhg-wpe/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "lhg-wpe"
 BBFILE_PATTERN_lhg-wpe = "^${LAYERDIR}/"
 BBFILE_PRIORITY_lhg-wpe = "7"
 
-LAYERSERIES_COMPAT_lhg-integration = "thud warrior zeus"
+LAYERSERIES_COMPAT_lhg-integration = "warrior zeus dunfell"

--- a/meta-lhg/conf/layer.conf
+++ b/meta-lhg/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "lhg"
 BBFILE_PATTERN_lhg = "^${LAYERDIR}/"
 BBFILE_PRIORITY_lhg = "7"
 
-LAYERSERIES_COMPAT_lhg = "thud warrior zeus"
+LAYERSERIES_COMPAT_lhg = "warrior zeus dunfell"


### PR DESCRIPTION
meta-lhg has the thud branch already, so there is no need to keep thud
in LAYERSERIES_COMPAT for master.

Signed-off-by: Andrey Konovalov <andrey.konovalov@linaro.org>