### PR TITLE
igt-gpu-tools_git.bb: remove net-snmp

### DIFF
--- a/meta-lhg-integration/recipes-graphics/igt-gpu-tools/igt-gpu-tools_git.bb
+++ b/meta-lhg-integration/recipes-graphics/igt-gpu-tools/igt-gpu-tools_git.bb
@@ -14,7 +14,7 @@ SRC_URI = "git://gitlab.freedesktop.org/drm/igt-gpu-tools.git;protocol=https"
 S = "${WORKDIR}/git"
 
 DEPENDS += "libdrm libpciaccess cairo udev glib-2.0 procps libunwind kmod openssl xmlrpc-c gsl elfutils alsa-lib json-c bison-native"
-RDEPENDS_${PN} += "bash python3-mako python3-six git net-snmp"
+RDEPENDS_${PN} += "bash python3-mako python3-six git"
 
 PACKAGE_BEFORE_PN = "${PN}-benchmarks"
 


### PR DESCRIPTION
net-snmp is used for sending command to PDU to power cycle the
Chamelium. It is not necessary for igt-gpu-tools, so remove it for the
recipe.

Signed-off-by: Arthur <arthur.she@linaro.org>