### PR TITLE
meta-lhg*/layer.conf: switch LAYERSERIES_COMPAT to gatesgarth

### DIFF
--- a/meta-lhg-integration/conf/layer.conf
+++ b/meta-lhg-integration/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "lhg-integration"
 BBFILE_PATTERN_lhg-integration = "^${LAYERDIR}/"
 BBFILE_PRIORITY_lhg-integration = "7"
 
-LAYERSERIES_COMPAT_lhg-integration = "warrior zeus dunfell"
+LAYERSERIES_COMPAT_lhg-integration = "gatesgarth"

--- a/meta-lhg-wpe/conf/layer.conf
+++ b/meta-lhg-wpe/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "lhg-wpe"
 BBFILE_PATTERN_lhg-wpe = "^${LAYERDIR}/"
 BBFILE_PRIORITY_lhg-wpe = "7"
 
-LAYERSERIES_COMPAT_lhg-integration = "warrior zeus dunfell"
+LAYERSERIES_COMPAT_lhg-integration = "gatesgarth"

--- a/meta-lhg/conf/layer.conf
+++ b/meta-lhg/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "lhg"
 BBFILE_PATTERN_lhg = "^${LAYERDIR}/"
 BBFILE_PRIORITY_lhg = "7"
 
-LAYERSERIES_COMPAT_lhg = "warrior zeus dunfell"
+LAYERSERIES_COMPAT_lhg = "gatesgarth"


### PR DESCRIPTION
Let's keep only the last release name in master's LAYERSERIES_COMPAT.
Please use the relevant meta-lhg branches for older releases.

Signed-off-by: Andrey Konovalov <andrey.konovalov@linaro.org>